### PR TITLE
fixed language tag

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -11,6 +11,6 @@
     <summary lang="en">Backup and restore your XBMC database and configuration files in the event of a crash or file corruption.</summary>
     <description lang="en">Ever hosed your XBMC configuration and wished you'd had a backup? Now you can with one easy click. You can export your database, playlist, thumbnails, addons and other configuration details to any source writeable by XBMC.</description>
     <platform>all</platform>
-    <language>en fr</language>
+    <language></language>
   </extension>
 </addon>


### PR DESCRIPTION
The language tag in addon.xml is meant for the language of the content it provides (not for the translations it has).
It is mainly used for hiding "foreign language addons" - this addon doesn't provide content and is meant to be usable in all languages.
