### PR TITLE
Fix duplicate files in zip backups

### DIFF
--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -558,12 +558,11 @@ class XbmcBackup:
         rFile.close()
 
 class FileManager:
-    fileArray = []
     not_dir = ['.zip','.xsp','.rar']
-    vfs = None
 
     def __init__(self,vfs):
         self.vfs = vfs
+        self.fileArray = []
 
     def walkTree(self,directory):
        


### PR DESCRIPTION
Fix for #61.
The issue is FileManager.fileArray is persistent each time the class is constructed since it is a class variable, which only matters for the scheduler where it does multiple backups from a single execution of the script.
This is also a problem for non-zip backups, except that it just overwrites the same file multiple times rather than duplicating it.