### PR TITLE
Use TinyURL for OAuth

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -47,8 +47,8 @@
     <string id="30052">Writing file</string>
     <string id="30053">Starting scheduled backup</string>
     <string id="30054">Removing backup</string>
-    <string id="30056">Check log for Dropbox authorize URL</string>
-    <string id="30057">Click OK when authorized</string>
+    <string id="30056">Go to this URL to authorize</string>
+    <string id="30057">Click OK AFTER completion</string>
     <string id="30058">Dropbox Developer Code Needed</string>
     <string id="30059">Visit https://www.dropbox.com/developers</string>
     <string id="30060">Enable Scheduler</string>
@@ -93,4 +93,6 @@
 	<string id="30099">Open Settings</string>
 	<string id="30100">Extracting Archive</string>
 	<string id="30101">Error extracting the zip archive</string>
+	<string id="30102">Click OK to enter code</string>
+	<string id="30103">Google Drive Validation Code</string>
 </strings>

--- a/resources/lib/tinyurl.py
+++ b/resources/lib/tinyurl.py
@@ -1,0 +1,11 @@
+import urllib2
+
+#this is duplicated in snipppets of code from all over the web, credit to no one
+#in particular - to all those that have gone before me!
+def shorten(aUrl):
+    tinyurl = 'http://tinyurl.com/api-create.php?url='
+    req = urllib2.urlopen(tinyurl + aUrl)
+    data = req.read()
+
+    #should be a tiny url
+    return str(data)

--- a/resources/lib/vfs.py
+++ b/resources/lib/vfs.py
@@ -1,4 +1,5 @@
 import utils as utils
+import tinyurl as tinyurl
 import xbmc
 import xbmcvfs
 import xbmcgui
@@ -135,14 +136,14 @@ class DropboxFileSystem(Vfs):
         user_token_key,user_token_secret = self.getToken()
         
         sess = session.DropboxSession(self.APP_KEY,self.APP_SECRET,"app_folder")
-        utils.log("token:" + user_token_key + ":" + user_token_secret)
+        
         if(user_token_key == '' and user_token_secret == ''):
             token = sess.obtain_request_token()
             url = sess.build_authorize_url(token)
 
             #print url in log
             utils.log("Authorize URL: " + url)
-            xbmcgui.Dialog().ok(utils.getString(30010),utils.getString(30056),utils.getString(30057))  
+            xbmcgui.Dialog().ok(utils.getString(30010),utils.getString(30056),utils.getString(30057),tinyurl.shorten(url))
             
             #if user authorized this will work
             user_token = sess.obtain_access_token(token)
@@ -304,7 +305,8 @@ class GoogleDriveFilesystem(Vfs):
     
             utils.log("Google Drive Authorize URL: " + drive_url)
 
-            code = xbmcgui.Dialog().input('Google Drive Validation Code','Input the Validation code after authorizing this app')
+            xbmcgui.Dialog().ok(utils.getString(30010),utils.getString(30056),utils.getString(30102),tinyurl.shorten(drive_url))
+            code = xbmcgui.Dialog().input(utils.getString(30103))
 
             gauth.Auth(code)
             gauth.SaveCredentialsFile(xbmc.validatePath(xbmc.translatePath(utils.data_dir() + 'google_drive.dat')))


### PR DESCRIPTION
This gets rid of one of the biggest pains when setting up Dropbox or Google Drive - checking the Kodi log file for the url for the OAuth url. Fixes #87 