### PR TITLE
System Settings Updates - Matrix

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -7,9 +7,9 @@
     <import addon="script.module.future" version="0.18.2+matrix.1" />
     <import addon="script.module.dropbox" version="9.4.0" />
   </requires>
-  <extension point="xbmc.python.script" library="default.py"> 
-     <provides>executable</provides> 
-  </extension> 
+  <extension point="xbmc.python.script" library="default.py">
+     <provides>executable</provides>
+  </extension>
   <extension point="xbmc.service" library="service.py" />
   <extension point="xbmc.addon.metadata">
     <summary lang="ar_SA">إنسخ إحتياطياً قاعده بيانات إكس بى إم سى وملفات اﻹعدادات فى حاله وقوع إنهيار مع إمكانيه اﻹسترجاع</summary>
@@ -91,6 +91,7 @@
     </assets>
     <news>Version 1.6.4
  - updated deprecated Kodi python methods
+ - added better system settings/restore functionality (enabled by default)
 </news>
   </extension>
 </addon>

--- a/changelog.md
+++ b/changelog.md
@@ -6,10 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased](https://github.com/robweber/xbmcbackup/compare/matrix-1.6.3...matrix)
 
+### Added
+
+- merged duplicate copy code into ```_copyFile``` method
+- added method to backup/restore Kodi settings via the GetSettings/SetSettingValue JSON methods in the validation file
+- added setting to always restore settings or prompt at the time of backup 
+
 ### Changed
 
 - updated script.module.future version to current
 - swapped xbmc.translatePath for xbmcvfs.translatePath, deprecated
+
+### Removed
+
+- removed old xml GuiSettings parsing for settings restore
 
 ## [Version 1.6.3](https://github.com/robweber/xbmcbackup/compare/matrix-1.6.2...robweber:matrix-1.6.3) - 2020-06-15
 
@@ -55,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - addon.xml updated to use Leia specific syntax and library imports
  - removed specific encode() calls per Python2/3 compatibility
  - call isdigit() method on the string directly instead of str.isdigit() (results in unicode error)
- - added flake8 testing to travis-ci 
+ - added flake8 testing to travis-ci
  - updated code to make python3 compatible
  - updated code for pep9 styling
  - use setArt() to set ListItem icons as the icon= constructor is deprecated
@@ -73,16 +83,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
  - Updated Changelog format to the one suggested by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Added script.module.dropbox import as a dependency for Dropbox filesystem
- 
+
 ### Changed
 
- - Fixed issue getting xbmcbackup.val file from non-zipped remote directories. Was being copied as though it was a local file so it was failing. 
+ - Fixed issue getting xbmcbackup.val file from non-zipped remote directories. Was being copied as though it was a local file so it was failing.
  - Use linux path separator (/) all the time, Kodi will interpret this correctly on windows. Was causing issues with remote file systems since os.path.sep
- - Fixed minor python code style changes based on kodi-addon-checker output 
- 
+ - Fixed minor python code style changes based on kodi-addon-checker output
+
 ### Removed
 
- - files releated to dropbox library, using script.module.dropbox import now 
+ - files releated to dropbox library, using script.module.dropbox import now
 
 ## Version 1.5.1 - 2019-09-10
 
@@ -92,7 +102,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Version 1.5.0 - 2019-08-26
 
 ### Added
-- Added new Advanced file editor and file selection based on a .json 
+- Added new Advanced file editor and file selection based on a .json
 
 ### Removed
 - File backups and restores will not work with old version - breaking change with previous versions PR117
@@ -102,7 +112,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
  - added file chunk support for Dropbox uploads
  - added scheduler delay to assist with time sync (rpi mostly), will delay startup by 2 min
- 
+
 ### Changed
  - fixed settings duplicate ids, thanks aster-anto
 
@@ -114,7 +124,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## Version 1.1.1
 
 ### Added
- - added ability to "catchup" on missed scheduled backup 
+ - added ability to "catchup" on missed scheduled backup
 
 ### Changed
  - fixed error on authorizers (missing secret/key)
@@ -125,10 +135,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
  - added tinyurl generation for oauth urls
- 
+
 ### Changed
  - moved authorize to settings area for cloud storage
- 
+
 ## Version 1.0.9
 
 ### Changed
@@ -149,7 +159,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Added
 
  - added progress for zip extraction - hopefully helps with extract errors
- 
+
 ### Changed
  - fix for custom directories not working recursively
 
@@ -289,7 +299,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## Version 0.3.9
 
- - added "just once" scheduler for one-off type backups 
+ - added "just once" scheduler for one-off type backups
  - show  notification on scheduler  
  - update updated language files from  Transifex
 

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -581,3 +581,14 @@ msgctxt "#30147"
 msgid "Toggle Sub Folders"
 msgstr ""
 
+msgctxt "#30148"
+msgid "Always restore Kodi settings"
+msgstr ""
+
+msgctxt "#30149"
+msgid "Restore Kodi Settings"
+msgstr ""
+
+msgctxt "#30150"
+msgid "Restore saved Kodi system settings from backup?"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -582,11 +582,11 @@ msgid "Toggle Sub Folders"
 msgstr ""
 
 msgctxt "#30148"
-msgid "Always restore Kodi settings"
+msgid "Ask before restoring Kodi UI settings"
 msgstr ""
 
 msgctxt "#30149"
-msgid "Restore Kodi Settings"
+msgid "Restore Kodi UI Settings"
 msgstr ""
 
 msgctxt "#30150"

--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -288,7 +288,7 @@ class XbmcBackup:
             restoreSettings = utils.getSettingBool('always_restore_settings')
             if(not restoreSettings and 'system_settings' in valFile):
                 # prompt the user to restore settings yes/no
-                restoreSettings = xbmcgui.Dialog().yesno("Restore Kodi Settings","Restore saved Kodi system settings from backup?")
+                restoreSettings = xbmcgui.Dialog().yesno(utils.getString(30149),utils.getString(30150))
 
             # use a multiselect dialog to select sets to restore
             restoreSets = [n['name'] for n in valFile['directories']]
@@ -339,7 +339,7 @@ class XbmcBackup:
                 self.xbmc_vfs.rmdir(self.remote_vfs.root_path)
 
             # call update addons to refresh everything
-            #xbmc.executebuiltin('UpdateLocalAddons')
+            xbmc.executebuiltin('UpdateLocalAddons')
 
     def _setupVFS(self, mode=-1, progressOverride=False):
         # set windows setting to true

--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -284,6 +284,12 @@ class XbmcBackup:
                     xbmcgui.Dialog().ok(utils.getString(30077), utils.getString(30078))
                     return
 
+            # check if settings should be restored from this backup
+            restoreSettings = utils.getSettingBool('always_restore_settings')
+            if(not restoreSettings and 'system_settings' in valFile):
+                # prompt the user to restore settings yes/no
+                restoreSettings = xbmcgui.Dialog().yesno("Restore Kodi Settings","Restore saved Kodi system settings from backup?")
+
             # use a multiselect dialog to select sets to restore
             restoreSets = [n['name'] for n in valFile['directories']]
 
@@ -294,6 +300,7 @@ class XbmcBackup:
                 selectedSets = [restoreSets.index(n) for n in selectedSets if n in restoreSets]  # if set name not found just skip it
 
             if(selectedSets is not None):
+
                 # go through each of the directories in the backup and write them to the correct location
                 for index in selectedSets:
 
@@ -319,7 +326,7 @@ class XbmcBackup:
                     self._copyFiles(fileGroup['files'], self.remote_vfs, self.xbmc_vfs)
 
             # update the Kodi settings - if we can
-            if('system_settings' in valFile):
+            if('system_settings' in valFile and restoreSettings):
                 self.progressBar.updateProgress(98, "Restoring Kodi settings")
                 gui_settings = GuiSettingsManager()
                 gui_settings.restore(valFile['system_settings'])
@@ -332,7 +339,7 @@ class XbmcBackup:
                 self.xbmc_vfs.rmdir(self.remote_vfs.root_path)
 
             # call update addons to refresh everything
-            xbmc.executebuiltin('UpdateLocalAddons')
+            #xbmc.executebuiltin('UpdateLocalAddons')
 
     def _setupVFS(self, mode=-1, progressOverride=False):
         # set windows setting to true

--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -162,7 +162,6 @@ class XbmcBackup:
 
             # check if Kodi settings should also be dumped
             if(utils.getSettingBool('backup_copy_settings')):
-                utils.log('Backing up Kodi settings')
                 gui_settings = GuiSettingsManager()
                 gui_settings.backup()
 
@@ -293,6 +292,11 @@ class XbmcBackup:
                     xbmcgui.Dialog().ok(utils.getString(30077), utils.getString(30078))
                     return
 
+            # copy the Kodi settings file - if it exists
+            gui_settings = GuiSettingsManager()
+            if(self.remote_vfs.exists(self.remote_vfs.root_path + gui_settings.filename)):
+                self._copyFile(self.remote_vfs, self.xbmc_vfs, self.remote_vfs.root_path + gui_settings.filename, xbmcvfs.translatePath(utils.data_dir() +  gui_settings.filename))
+
             # use a multiselect dialog to select sets to restore
             restoreSets = [n['name'] for n in valFile['directories']]
 
@@ -329,14 +333,14 @@ class XbmcBackup:
 
             self.progressBar.updateProgress(99, "Clean up operations .....")
 
+            # update the Kodi settings - if we can
+            if(xbmcvfs.exists(xbmcvfs.translatePath(utils.data_dir() + gui_settings.filename))):
+                gui_settings.restore()
+
             if(self.restore_point.split('.')[-1] == 'zip'):
                 # delete the zip file and the extracted directory
                 self.xbmc_vfs.rmfile(xbmcvfs.translatePath("special://temp/" + self.restore_point))
                 self.xbmc_vfs.rmdir(self.remote_vfs.root_path)
-
-            # update the guisettings information (or what we can from it)
-            gui_settings = GuiSettingsManager()
-            gui_settings.run()
 
             # call update addons to refresh everything
             xbmc.executebuiltin('UpdateLocalAddons')

--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -288,7 +288,7 @@ class XbmcBackup:
             restoreSettings = utils.getSettingBool('always_restore_settings')
             if(not restoreSettings and 'system_settings' in valFile):
                 # prompt the user to restore settings yes/no
-                restoreSettings = xbmcgui.Dialog().yesno(utils.getString(30149),utils.getString(30150))
+                restoreSettings = xbmcgui.Dialog().yesno(utils.getString(30149), utils.getString(30150))
 
             # use a multiselect dialog to select sets to restore
             restoreSets = [n['name'] for n in valFile['directories']]

--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -285,7 +285,7 @@ class XbmcBackup:
                     return
 
             # check if settings should be restored from this backup
-            restoreSettings = utils.getSettingBool('always_restore_settings')
+            restoreSettings = not utils.getSettingBool('always_prompt_restore_settings')
             if(not restoreSettings and 'system_settings' in valFile):
                 # prompt the user to restore settings yes/no
                 restoreSettings = xbmcgui.Dialog().yesno(utils.getString(30149), utils.getString(30150))

--- a/resources/lib/backup.py
+++ b/resources/lib/backup.py
@@ -160,6 +160,15 @@ class XbmcBackup:
                 if(not shouldContinue):
                     return
 
+            # check if Kodi settings should also be dumped
+            if(utils.getSettingBool('backup_copy_settings')):
+                utils.log('Backing up Kodi settings')
+                gui_settings = GuiSettingsManager()
+                gui_settings.backup()
+
+                # add this file to the backup
+                self.remote_vfs.put(xbmcvfs.translatePath(utils.data_dir() + gui_settings.filename), self.remote_vfs.root_path + gui_settings.filename)
+
             orig_base_path = self.remote_vfs.root_path
 
             # backup all the files

--- a/resources/lib/guisettings.py
+++ b/resources/lib/guisettings.py
@@ -7,6 +7,7 @@ from xml.parsers.expat import ExpatError
 
 
 class GuiSettingsManager:
+    filename = 'kodi_settings.json'
     doc = None
 
     def __init__(self):
@@ -16,8 +17,18 @@ class GuiSettingsManager:
         # read in the copy
         self._readFile(xbmcvfs.translatePath('special://home/userdata/guisettings.xml.restored'))
 
+    def backup(self):
+        # get all of the current Kodi settings
+        json_response = json.loads(xbmc.executeJSONRPC('{"jsonrpc":"2.0", "id":1, "method":"Settings.GetSettings","params":{"level":"advanced"}}'))
+
+        # write the settings as a json object to the addon data directory
+        sFile = xbmcvfs.File(xbmcvfs.translatePath(utils.data_dir() + self.filename), 'w')
+        sFile.write(json.dumps(json_response['result']['settings']))
+        sFile.write("")
+        sFile.close()
+
     def run(self):
-        # get a list of all the settings we can manipulate via json
+        # get all of the current Kodi settings
         json_response = json.loads(xbmc.executeJSONRPC('{"jsonrpc":"2.0", "id":1, "method":"Settings.GetSettings","params":{"level":"advanced"}}'))
 
         settings = json_response['result']['settings']

--- a/resources/lib/guisettings.py
+++ b/resources/lib/guisettings.py
@@ -10,7 +10,7 @@ class GuiSettingsManager:
 
     def __init__(self):
         # get all of the current Kodi settings
-        json_response = json.loads(xbmc.executeJSONRPC('{"jsonrpc":"2.0", "id":1, "method":"Settings.GetSettings","params":{"level":"advanced"}}'))
+        json_response = json.loads(xbmc.executeJSONRPC('{"jsonrpc":"2.0", "id":1, "method":"Settings.GetSettings","params":{"level":"expert"}}'))
 
         self.systemSettings = json_response['result']['settings']
 

--- a/resources/lib/guisettings.py
+++ b/resources/lib/guisettings.py
@@ -31,7 +31,7 @@ class GuiSettingsManager:
             if(aSetting['type'] != 'action'):
                 settingsDict[aSetting['id']] = aSetting['value']
 
-        restoreCount = 0;
+        restoreCount = 0
         for aSetting in restoreSettings:
             # only update a setting if its different than the current (action types have no value)
             if(aSetting['type'] != 'action' and settingsDict[aSetting['id']] != aSetting['value']):

--- a/resources/lib/guisettings.py
+++ b/resources/lib/guisettings.py
@@ -1,6 +1,5 @@
 import json
 import xbmc
-import xbmcvfs
 from . import utils as utils
 
 

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,8 +3,8 @@
 	<category id="general" label="30011" level="expert">
 		<setting id="compress_backups" type="bool" label="30087" default="false" />
 		<setting id="backup_rotation" type="number" label="30026" default="0" />
+    <setting id="always_restore_settings" type="bool" label="30148" default="true" />
 		<setting id="progress_mode" type="enum" label="30022" lvalues="30082|30083|30084" default="0" />
-    <setting id="always_restore_settings" type="bool" label="Always restore Kodi settings" default="true" />
 		<setting type="sep" />
 		<setting id="verbose_logging" type="bool" label="Enable Verbose Logging" default="false" />
 		<setting id="upgrade_notes" type="number" label="upgrade_notes" visible="false" default="1" />

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,7 +3,7 @@
 	<category id="general" label="30011" level="expert">
 		<setting id="compress_backups" type="bool" label="30087" default="false" />
 		<setting id="backup_rotation" type="number" label="30026" default="0" />
-    <setting id="always_restore_settings" type="bool" label="30148" default="true" />
+    <setting id="always_prompt_restore_settings" type="bool" label="30148" default="false" />
 		<setting id="progress_mode" type="enum" label="30022" lvalues="30082|30083|30084" default="0" />
 		<setting type="sep" />
 		<setting id="verbose_logging" type="bool" label="Enable Verbose Logging" default="false" />

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,6 +4,7 @@
 		<setting id="compress_backups" type="bool" label="30087" default="false" />
 		<setting id="backup_rotation" type="number" label="30026" default="0" />
 		<setting id="progress_mode" type="enum" label="30022" lvalues="30082|30083|30084" default="0" />
+    <setting id="always_restore_settings" type="bool" label="Always restore Kodi settings" default="true" />
 		<setting type="sep" />
 		<setting id="verbose_logging" type="bool" label="Enable Verbose Logging" default="false" />
 		<setting id="upgrade_notes" type="number" label="upgrade_notes" visible="false" default="1" />
@@ -21,8 +22,6 @@
 		<setting id="remove_auth_button" type="action" label="30093" action="RunScript(special://home/addons/script.xbmcbackup/launcher.py,action=remove_auth)" visible="gt(-9,1)"/>
 	</category>
 	<category id="selection" label="30012">
-		<setting id="backup_copy_settings" type="bool" label="Save Kodi Settings" default="true" />
-		<setting type="sep" />
 		<setting id="backup_selection_type" type="enum" lvalues="30014|30015" default="0" label="30023" />
 		<setting id="backup_addon_data" type="bool" label="30031" default="false" visible="eq(-1,0)"/>
 		<setting id="backup_config" type="bool" label="30035" default="true" visible="eq(-2,0)"/>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -21,6 +21,8 @@
 		<setting id="remove_auth_button" type="action" label="30093" action="RunScript(special://home/addons/script.xbmcbackup/launcher.py,action=remove_auth)" visible="gt(-9,1)"/>
 	</category>
 	<category id="selection" label="30012">
+		<setting id="backup_copy_settings" type="bool" label="Save Kodi Settings" default="true" />
+		<setting type="sep" />
 		<setting id="backup_selection_type" type="enum" lvalues="30014|30015" default="0" label="30023" />
 		<setting id="backup_addon_data" type="bool" label="30031" default="false" visible="eq(-1,0)"/>
 		<setting id="backup_config" type="bool" label="30035" default="true" visible="eq(-2,0)"/>


### PR DESCRIPTION
This both fixes #169 and enhances the overall system settings backup and restore process. 

### Old Process

The old restore process read in the guisettings.xml file (hopefully already restored as part of restoral operation). It then pulled the currently running system settings via a ```System.GetSettings``` JSON call and compared them. Where different it would then update the settings. 

### Issues

There are two main issues with this process. The first is that it assumed all read in values where either strings or integers. The xml structure didn't give a type so this was inferred. The actual definitions of these settings included more types than this, including boolean and list values. As a result these were not set correctly. The second issue is that this system relied on the end-user to have made sure to back up the guisettings.xml file and include it as part of their restore. This wasn't very well documented for the end user and may have resulted in these settings just not being available. Many users assume database backups are sufficient to capture UI settings. 

### New Method

The new method tries to fix these issues. As part of every backup the contents of the ```System.GetSettings``` call exported as part of the validation file. This captures the UI settings on every backup run, regardless of if they will be restored. It also captures the definitions of the settings and types of each - which are useful for the restore operation. As part of the restores these settings are updated in Kodi, again where different than current, but only if one of two conditions is true. The first is if the new "always prompt restore" option is unchecked (default). This assumes the user will want UI settings restored, when found, by default. If checked the user will be prompted at the time of the restore and can accept or decline that the settings be updated. 