### PR TITLE
Add check for settings id key in dict when importing GUI settings

### DIFF
--- a/resources/lib/guisettings.py
+++ b/resources/lib/guisettings.py
@@ -33,10 +33,12 @@ class GuiSettingsManager:
 
         restoreCount = 0
         for aSetting in restoreSettings:
+            # Ensure key exists before referencing
+            if(aSetting['id'] in settingsDict.values()):
             # only update a setting if its different than the current (action types have no value)
-            if(aSetting['type'] != 'action' and settingsDict[aSetting['id']] != aSetting['value']):
-                if(utils.getSettingBool('verbose_logging')):
-                    utils.log('%s different than current: %s' % (aSetting['id'], str(aSetting['value'])))
+                if(aSetting['type'] != 'action' and settingsDict[aSetting['id']] != aSetting['value']):
+                    if(utils.getSettingBool('verbose_logging')):
+                        utils.log('%s different than current: %s' % (aSetting['id'], str(aSetting['value'])))
 
                 updateJson['params']['setting'] = aSetting['id']
                 updateJson['params']['value'] = aSetting['value']


### PR DESCRIPTION
Fix for crash when importing GUI settings if the backup'd settings contains a key which isn't present in the Kodi it's being restored to.